### PR TITLE
Adding Multi-Clients support to single thread server

### DIFF
--- a/ipc/shmem_ipc/ipc.h
+++ b/ipc/shmem_ipc/ipc.h
@@ -6,7 +6,7 @@
 #define JOB_REQUESTED  1
 #define JOB_COMPLETED  2
 #define BUF_IN_USE  3
-#define MAX_CLIENT_PER_BUF 1
+#define MAX_CLIENT_PER_BUF 2
 
 typedef struct JobRequestBuffer {
     int fd;               // File descriptor

--- a/ipc/shmem_ipc/ipc.h
+++ b/ipc/shmem_ipc/ipc.h
@@ -5,6 +5,8 @@
 #define JOB_NO_REQUEST 0
 #define JOB_REQUESTED  1
 #define JOB_COMPLETED  2
+#define BUF_IN_USE  3
+#define MAX_CLIENT_PER_BUF 1
 
 typedef struct JobRequestBuffer {
     int fd;               // File descriptor
@@ -12,7 +14,7 @@ typedef struct JobRequestBuffer {
     int response;         // Response from the server
 	char buffer[128];	  // Command buffer
 	int buffer_len;		  // Commabd buffer length
-    volatile int status;  // Flag indicating which stage the job is at
+    volatile int status[MAX_CLIENT_PER_BUF];  // Flag indicating which stage the job is at
 } JobRequestBuffer_t;
 
 #define SHMEM_REGION_SIZE 512

--- a/ipc/shmem_ipc/run_benchmark.sh
+++ b/ipc/shmem_ipc/run_benchmark.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 LOOP_COUNT=10
-CLIENTS=1
+CLIENTS=2
 
 function RunApproach1 {
 	log_file=approach1_log.txt
@@ -102,7 +102,7 @@ function RunApproach5 {
 	i=0
 	while [ $i -lt $LOOP_COUNT ]
 	do
-    	taskset -c 0 ./server_elevated 200000 &> /dev/null &
+    	taskset -c 0 ./server 200000 ${CLIENTS} &> /dev/null &
     	server_pid=$!
 
 		sleep 0.08
@@ -119,13 +119,36 @@ function RunApproach5 {
 	printf "\n"
 }
 
+function RunApproach6 {
+	log_file=approach6_log.txt
+
+    rm -rf $log_file
+
+	printf "Approach 6: ${CLIENTS} Independent Clients\n"
+
+	i=0
+	while [ $i -lt $LOOP_COUNT ]
+	do
+		for (( c=1; c<=${CLIENTS}; c++ ))
+		do 
+			sleep 0.01; taskset -c $c ./independent_client 200000 &> /dev/null >> $log_file &
+		done
+    
+    	wait
+    	i=$(( $i + 1 ))
+		echo -n -e '  Completed Iterations: '"$i/$LOOP_COUNT"'\r'
+		sleep 0.06
+	done
+	printf "\n"
+}
 
 printf "Choose one of the four approaches to IPC to test\n"
 printf "\t[1] Independent client (un-elevated)\n"
 printf "\t[2] Independent client (elevated + shortcutted)\n"
 printf "\t[3] Client + un-elevated Server\n"
 printf "\t[4] Client + elevated and shortcutted Server\n"
-printf "\t[5] ${CLIENTS} Client + elevated Server\n\n"
+printf "\t[5] ${CLIENTS} Client + elevated Server\n"
+printf "\t[6] ${CLIENTS} Independent Clients\n\n"
 
 
 read -p "Select your choice: " test_choice
@@ -140,5 +163,7 @@ elif [ $test_choice == "4" ]; then
     RunApproach4
 elif [ $test_choice == "5" ]; then
     RunApproach5
+elif [ $test_choice == "6" ]; then
+    RunApproach6
 fi
 

--- a/ipc/shmem_ipc/run_benchmark.sh
+++ b/ipc/shmem_ipc/run_benchmark.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-LOOP_COUNT=50
+LOOP_COUNT=10
+CLIENTS=1
 
 function RunApproach1 {
 	log_file=approach1_log.txt
@@ -91,11 +92,41 @@ function RunApproach4 {
 	printf "\n"
 }
 
+function RunApproach5 {
+	log_file=approach5_log.txt
+
+    rm -rf $log_file
+
+	printf "Approach 5: ${CLIENTS} Client + Server\n"
+
+	i=0
+	while [ $i -lt $LOOP_COUNT ]
+	do
+    	taskset -c 0 ./server_elevated 200000 &> /dev/null &
+    	server_pid=$!
+
+		sleep 0.08
+		for (( c=1; c<=${CLIENTS}; c++ ))
+		do 
+			sleep 0.01; taskset -c $c ./client 200000 &> /dev/null >> $log_file &
+		done
+    
+    	wait
+    	i=$(( $i + 1 ))
+		echo -n -e '  Completed Iterations: '"$i/$LOOP_COUNT"'\r'
+		sleep 0.06
+	done
+	printf "\n"
+}
+
+
 printf "Choose one of the four approaches to IPC to test\n"
 printf "\t[1] Independent client (un-elevated)\n"
 printf "\t[2] Independent client (elevated + shortcutted)\n"
 printf "\t[3] Client + un-elevated Server\n"
-printf "\t[4] Client + elevated and shortcutted Server\n\n"
+printf "\t[4] Client + elevated and shortcutted Server\n"
+printf "\t[5] ${CLIENTS} Client + elevated Server\n\n"
+
 
 read -p "Select your choice: " test_choice
 
@@ -107,5 +138,7 @@ elif [ $test_choice == "3" ]; then
     RunApproach3
 elif [ $test_choice == "4" ]; then
     RunApproach4
+elif [ $test_choice == "5" ]; then
+    RunApproach5
 fi
 

--- a/ipc/shmem_ipc/server.c
+++ b/ipc/shmem_ipc/server.c
@@ -5,6 +5,8 @@
 static ksys_write_t my_ksys_write = NULL;
 #endif
 
+int NUM_CLIENTS=1;
+
 int main(int argc, char** argv) {
 	(void)argc;
 	int iterations = atoi(argv[1]);
@@ -20,6 +22,8 @@ int main(int argc, char** argv) {
 	// Create a file to write to
 	FILE* log = fopen("stress_test_log", "w");
 	int logfd = fileno(log);
+
+	NUM_CLIENTS = atoi(argv[2]);
 
 	// Prepare the job buffer
 	JobRequestBuffer_t* job_buffer = (JobRequestBuffer_t*)shared_memory;
@@ -38,7 +42,7 @@ int main(int argc, char** argv) {
 			if (current_idx == MAX_CLIENT_PER_BUF){
 				current_idx = 0;
 			}
-			if (i== (iterations*MAX_CLIENT_PER_BUF)){
+			if (i== (iterations*NUM_CLIENTS)){
 				#ifdef ELEVATED_MODE
 				sym_lower();
 				#endif


### PR DESCRIPTION
**Summary of the changes** 
> 
- Job buffer has an array of statuses ( _int status[N]_ ), where each **ONE** status responds to **ONE** client
- The pull loop will spin on the array of statuses, and pick up requests if there is one.
- Each **ONE** of the job buffers will communicate with **N** client process.
- Clients are hard-coded to search for an open seat.
- Added test scripts for the following cases
> -  N independent clients. 
> -  N clients + single thread server.

This version is still a simple prototype. 